### PR TITLE
Fixes to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ on:
         type: choice
         description: 'Release Level'
         options:
+        - release
         - patch
         - minor
         - major
-        - release
         - rc
         - beta
         - alpha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           crate: cargo-release
       - name: 🚀 Release
-        run: cargo release --quiet --execute ${{ github.event.inputs.release-level }}
+        run: cargo release --no-confirm --execute ${{ github.event.inputs.release-level }}
         env:
           CRATE_NAME: tc
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
* Add `--no-confirm` option as the build got stuck waiting for output
* Make `--release` default option

For #38 