### PR TITLE
Add intermediate types for parsing

### DIFF
--- a/src/class/htb.rs
+++ b/src/class/htb.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    errors::TcError,
-    types::*,
-};
+use crate::{errors::TcError, types::*};
 
 /// Defined in `include/uapi/linux/pkt_sched.h`.
 #[derive(Default, Debug, PartialEq)]
@@ -102,30 +99,36 @@ fn unmarshal_htb(opts: Vec<TcOption>) -> Htb {
             TcaHtb::Init => htb.init = unmarshal_htb_glob(opt.bytes.as_slice()).ok(),
             TcaHtb::Ctab => htb.ctab = opt.bytes,
             TcaHtb::Rtab => htb.rtab = opt.bytes,
-            TcaHtb::DirectQlen => htb.direct_qlen = {
-                if opt.bytes.len() < 4 {
-                    // TODO: log error
-                    None
-                } else {
-                    Some(u32::from_ne_bytes(opt.bytes[0..4].try_into().unwrap()))
+            TcaHtb::DirectQlen => {
+                htb.direct_qlen = {
+                    if opt.bytes.len() < 4 {
+                        // TODO: log error
+                        None
+                    } else {
+                        Some(u32::from_ne_bytes(opt.bytes[0..4].try_into().unwrap()))
+                    }
                 }
-            },
-            TcaHtb::Rate64 => htb.rate64 = {
-                if opt.bytes.len() < 8 {
-                    // TODO: log error
-                    None
-                } else {
-                    Some(u64::from_ne_bytes(opt.bytes[0..8].try_into().unwrap()))
+            }
+            TcaHtb::Rate64 => {
+                htb.rate64 = {
+                    if opt.bytes.len() < 8 {
+                        // TODO: log error
+                        None
+                    } else {
+                        Some(u64::from_ne_bytes(opt.bytes[0..8].try_into().unwrap()))
+                    }
                 }
-            },
-            TcaHtb::Ceil64 => htb.ceil64 = {
-                if opt.bytes.len() < 8 {
-                    // TODO: log error
-                    None
-                } else {
-                    Some(u64::from_ne_bytes(opt.bytes[0..8].try_into().unwrap()))
+            }
+            TcaHtb::Ceil64 => {
+                htb.ceil64 = {
+                    if opt.bytes.len() < 8 {
+                        // TODO: log error
+                        None
+                    } else {
+                        Some(u64::from_ne_bytes(opt.bytes[0..8].try_into().unwrap()))
+                    }
                 }
-            },
+            }
             _ => (),
         }
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,3 @@
-pub const ATTR_LEN: usize = 4;
-
 // QDiscs
 pub const CLSACT: &str = "clsact";
 pub const FQ_CODEL: &str = "fq_codel";

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,6 +41,12 @@ pub enum TcError {
     #[error("Failed to unmarshal struct: {0}")]
     UnmarshalStruct(#[from] Box<ErrorKind>),
 
+    #[error("Failed to unmarshal structs: {0}")]
+    UnmarshalStructs(String),
+
     #[error("Inavalid attribute: {0}")]
     InvalidAttribute(String),
+
+    #[error("Attribute not implemented: {0}")]
+    UnimplementedAttribute(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ mod qdiscs;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod test_data;
 
 pub use class::*;
 pub use netlink::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@ mod netlink;
 mod qdiscs;
 
 #[cfg(test)]
-mod tests;
-#[cfg(test)]
 mod test_data;
+#[cfg(test)]
+mod tests;
 
 pub use class::*;
 pub use netlink::*;

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,34 +1,14 @@
-use netlink_packet_route::nlas::link::Nla;
-
 use crate::{errors::LinkError, netlink, Link};
 
-/// `links` parses `LinkMessage`s into `Link`s and returns them.
+/// `links` parses intermediate representation of netlink link messages `LinkMsg`s into `Link`s.
 pub fn links<T: netlink::NetlinkConnection>() -> Result<Vec<Link>, LinkError> {
     let mut links = Vec::new();
 
     let messages = T::new()?.links()?;
     for message in messages {
-        let index = message.header.index;
-        let mut name = None;
-
-        for attr in message.nlas {
-            match attr {
-                Nla::IfName(ifname) => {
-                    name = Some(ifname);
-                }
-                _ => (),
-            }
-        }
-
-        if name.is_none() {
-            return Err(LinkError::MissingAttribute(
-                "Interface name not found".to_string(),
-            ));
-        }
-
         links.push(Link {
-            index,
-            name: name.unwrap(),
+            index: message.header.index,
+            name: message.attr.name
         });
     }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -8,7 +8,7 @@ pub fn links<T: netlink::NetlinkConnection>() -> Result<Vec<Link>, LinkError> {
     for message in messages {
         links.push(Link {
             index: message.header.index,
-            name: message.attr.name
+            name: message.attr.name,
         });
     }
 

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -1,10 +1,13 @@
+use std::vec;
+
 use netlink_packet_core::{
     NetlinkHeader, NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST,
 };
-use netlink_packet_route::{LinkMessage, RtnlMessage, TcHeader, TcMessage};
+use netlink_packet_route::{LinkMessage, RtnlMessage, TcMessage, link, tc as netlink_tc};
+use netlink_packet_utils::{Emitable, nla::Nla};
 use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
 
-use crate::errors::NetlinkError;
+use crate::{errors::NetlinkError, types::*};
 
 /// A trait for a netlink connection.
 ///
@@ -17,13 +20,13 @@ pub trait NetlinkConnection {
         Self: Sized;
 
     /// Get all qdiscs from Netlink.
-    fn qdiscs(&self) -> Result<Vec<TcMessage>, NetlinkError>;
+    fn qdiscs(&self) -> Result<Vec<TcMsg>, NetlinkError>;
 
     /// Get all classes from Netlink.
-    fn classes(&self, index: i32) -> Result<Vec<TcMessage>, NetlinkError>;
+    fn classes(&self, index: i32) -> Result<Vec<TcMsg>, NetlinkError>;
 
     /// Get all links from Netlink.
-    fn links(&self) -> Result<Vec<LinkMessage>, NetlinkError>;
+    fn links(&self) -> Result<Vec<LinkMsg>, NetlinkError>;
 }
 
 /// A struct for communicating with the kernel via netlink.
@@ -44,7 +47,7 @@ impl NetlinkConnection for Netlink {
         Ok(Self { socket })
     }
 
-    fn qdiscs(&self) -> Result<Vec<TcMessage>, NetlinkError> {
+    fn qdiscs(&self) -> Result<Vec<TcMsg>, NetlinkError> {
         send_get_qdisc_request(&self.socket)?;
 
         let mut receive_buffer = vec![0; 4096];
@@ -64,7 +67,7 @@ impl NetlinkConnection for Netlink {
                     NetlinkPayload::Error(error) => {
                         return Err(NetlinkError::Netlink(error.to_string()))
                     }
-                    NetlinkPayload::Done(_) => return Ok(tc_messages),
+                    NetlinkPayload::Done(_) => return Ok(to_tc(tc_messages)),
                     _ => {}
                 }
 
@@ -76,10 +79,10 @@ impl NetlinkConnection for Netlink {
             }
         }
 
-        Ok(tc_messages)
+        Ok(to_tc(tc_messages))
     }
 
-    fn classes(&self, index: i32) -> Result<Vec<TcMessage>, NetlinkError> {
+    fn classes(&self, index: i32) -> Result<Vec<TcMsg>, NetlinkError> {
         send_get_class_request(&self.socket, index)?;
 
         let mut receive_buffer = vec![0; 4096];
@@ -99,7 +102,7 @@ impl NetlinkConnection for Netlink {
                     NetlinkPayload::Error(error) => {
                         return Err(NetlinkError::Netlink(error.to_string()))
                     }
-                    NetlinkPayload::Done(_) => return Ok(tc_messages),
+                    NetlinkPayload::Done(_) => return Ok(to_tc(tc_messages)),
                     _ => {}
                 }
 
@@ -111,16 +114,16 @@ impl NetlinkConnection for Netlink {
             }
         }
 
-        Ok(tc_messages)
+        Ok(to_tc(tc_messages))
     }
 
-    fn links(&self) -> Result<Vec<LinkMessage>, NetlinkError> {
+    fn links(&self) -> Result<Vec<LinkMsg>, NetlinkError> {
         send_get_link_request(&self.socket)?;
 
         let mut receive_buffer = vec![0; 4096];
         let mut offset = 0;
 
-        let mut tc_messages = Vec::new();
+        let mut link_messages = Vec::new();
         while let Ok(size) = self.socket.recv(&mut &mut receive_buffer[..], 0) {
             loop {
                 let bytes = &receive_buffer[offset..];
@@ -129,12 +132,12 @@ impl NetlinkConnection for Netlink {
                 let payload = rx_packet.payload;
                 match payload {
                     NetlinkPayload::InnerMessage(RtnlMessage::NewLink(message)) => {
-                        tc_messages.push(message.clone())
+                        link_messages.push(message.clone())
                     }
                     NetlinkPayload::Error(error) => {
                         return Err(NetlinkError::Netlink(error.to_string()))
                     }
-                    NetlinkPayload::Done(_) => return Ok(tc_messages),
+                    NetlinkPayload::Done(_) => return Ok(to_link(link_messages)),
                     _ => {}
                 }
 
@@ -146,7 +149,7 @@ impl NetlinkConnection for Netlink {
             }
         }
 
-        Ok(tc_messages)
+        Ok(to_link(link_messages))
     }
 }
 
@@ -173,7 +176,7 @@ fn send_get_class_request(socket: &Socket, index: i32) -> Result<(), NetlinkErro
     let mut nl_hdr = NetlinkHeader::default();
     nl_hdr.flags = NLM_F_REQUEST | NLM_F_DUMP;
 
-    let tc_hdr = TcHeader {
+    let tc_hdr = netlink_tc::TcHeader {
         index,
         ..Default::default()
     };
@@ -211,4 +214,121 @@ fn send_get_link_request(socket: &Socket) -> Result<(), NetlinkError> {
         Ok(_) => Ok(()),
         Err(e) => Err(NetlinkError::Send(e.to_string())),
     }
+}
+
+fn to_tc(tc_messages: Vec<TcMessage>) -> Vec<TcMsg> {
+    tc_messages
+        .into_iter()
+        .map(|tc_message| {
+            let TcMessage { header: tc_header, nlas, .. } = tc_message;
+            let header = TcHeader {
+                index: tc_header.index,
+                handle: tc_header.handle,
+                parent: tc_header.parent,
+            };
+            let mut attrs = Vec::new();
+
+            for nla in nlas {
+                match nla {
+                    netlink_tc::Nla::Kind(kind) => attrs.push(TcAttr::Kind(kind)),
+                    netlink_tc::Nla::Options(tc_opts) => {
+                        let mut opts = Vec::new();
+                        for opt in tc_opts {
+                            match opt {
+                                netlink_tc::TcOpt::Ingress => {
+                                    let option = TcOption {
+                                        kind: 0u16, // TODO: what is Ingress kind?
+                                        bytes: vec![],
+                                    };
+                                    opts.push(option);
+                                },
+                                netlink_tc::TcOpt::U32(nla) => {
+                                    let mut buf = vec![0u8; nla.buffer_len()];
+                                    nla.emit_value(buf.as_mut_slice());
+                                    let option = TcOption {
+                                        kind: nla.kind(),
+                                        bytes: buf,
+                                    };
+                                    opts.push(option);
+                                },
+                                netlink_tc::TcOpt::Matchall(nla) => {
+                                    let mut buf = vec![0u8; nla.buffer_len()];
+                                    nla.emit_value(buf.as_mut_slice());
+                                    let option = TcOption {
+                                        kind: nla.kind(),
+                                        bytes: buf,
+                                    };
+                                    opts.push(option);
+                                },
+                                netlink_tc::TcOpt::Other(nla) => {
+                                    let mut buf = vec![0u8; nla.buffer_len()];
+                                    nla.emit_value(buf.as_mut_slice());
+                                    let option = TcOption {
+                                        kind: nla.kind(),
+                                        bytes: buf,
+                                    };
+                                    opts.push(option);
+                                },
+                                _ => (),
+
+                            };
+                        }
+                        attrs.push(TcAttr::Options(opts));
+                    }
+                    netlink_tc::Nla::Stats(tc_stats) => {
+                        let mut buf = Vec::new();
+                        tc_stats.emit(buf.as_mut_slice());
+                        attrs.push(TcAttr::Stats(buf));
+                    }
+                    netlink_tc::Nla::Stats2(tc_stats) => {
+                        let mut stats2 = Vec::new();
+                        for stat in tc_stats {
+                            match stat {
+                                netlink_tc::Stats2::StatsBasic(bytes) => stats2.push(TcStats2::StatsBasic(bytes)),
+                                netlink_tc::Stats2::StatsQueue(bytes) => stats2.push(TcStats2::StatsQueue(bytes)),
+                                netlink_tc::Stats2::StatsApp(bytes) => stats2.push(TcStats2::StatsApp(bytes)),
+                                _ => (),
+                            }
+                        }
+                        attrs.push(TcAttr::Stats2(stats2));
+                    }
+                    netlink_tc::Nla::XStats(bytes) => attrs.push(TcAttr::Xstats(bytes)),
+                    netlink_tc::Nla::Rate(bytes) => attrs.push(TcAttr::Rate(bytes)),
+                    netlink_tc::Nla::Fcnt(bytes) => attrs.push(TcAttr::Fcnt(bytes)),
+                    netlink_tc::Nla::Stab(bytes) => attrs.push(TcAttr::Stab(bytes)),
+                    netlink_tc::Nla::Chain(bytes) => attrs.push(TcAttr::Chain(bytes)),
+                    netlink_tc::Nla::HwOffload(byte) => attrs.push(TcAttr::HwOffload(byte)),
+                    _ => ()
+                }
+            }
+
+            TcMsg { header, attrs }
+        })
+        .collect()
+}
+
+
+fn to_link(link_messages: Vec<LinkMessage>) -> Vec<LinkMsg> {
+    link_messages
+        .into_iter()
+        .map(|link_message| {
+            let LinkMessage { header: link_header, nlas, .. } = link_message;
+            let header = LinkHeader {
+                index: link_header.index,
+            };
+
+            let mut name = String::new();
+            for nla in nlas {
+                match nla {
+                    link::nlas::Nla::IfName(if_name) => name = if_name,
+                    _ => ()
+                }
+            }
+
+            LinkMsg {
+                header,
+                attr: LinkAttr { name }
+            }
+        })
+        .collect()
 }

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -1,0 +1,517 @@
+use netlink_packet_route::{TcMessage, TcHeader as NlTcHeader, tc, LinkMessage, nlas};
+use netlink_packet_utils::{Parseable, nla};
+
+use crate::types::*;
+
+pub fn nl_qdiscs() -> Vec<TcMessage> {
+    let mut messages = Vec::with_capacity(3);
+
+        // noqueue
+        // TcMessage { header: TcHeader { family: 0, index: 1, handle: 0, parent: 4294967295, info: 2 }, nlas: [Kind("noqueue"), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
+        let header = NlTcHeader {
+            family: 0,
+            index: 1,
+            handle: 0,
+            parent: 4294967295,
+            info: 2,
+        };
+        let nlas = vec![
+            tc::nlas::Nla::Kind("noqueue".to_string()),
+            tc::nlas::Nla::HwOffload(0),
+            tc::nlas::Nla::Stats2(vec![
+                tc::nlas::Stats2::StatsBasic(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                    0, 0, 0, 0, // packets
+                    0, 0, 0, 0, // padding
+                ]),
+                tc::nlas::Stats2::StatsQueue(vec![
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // requeues
+                    0, 0, 0, 0, // overlimits
+                ]),
+            ]),
+            tc::nlas::Nla::Stats({
+                let buf = [
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // packets
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // overlimits
+                    0, 0, 0, 0, // bps
+                    0, 0, 0, 0, // pps
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                ];
+                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+                tc::nlas::Stats::parse(&stats_buf).unwrap()
+            }),
+        ];
+        messages.push(TcMessage::from_parts(header, nlas));
+
+        // mq
+        // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 4294967295, info: 1 }, nlas: [Kind("mq"), HwOffload(0), Stats2([StatsBasic([28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
+        let header = NlTcHeader {
+            family: 0,
+            index: 2,
+            handle: 0,
+            parent: 4294967295,
+            info: 1,
+        };
+        let nlas = vec![
+            tc::nlas::Nla::Kind("mq".to_string()),
+            tc::nlas::Nla::HwOffload(0),
+            tc::nlas::Nla::Stats2(vec![
+                tc::nlas::Stats2::StatsBasic(vec![
+                    28, 146, 82, 7, 0, 0, 0, 0, // bytes
+                    119, 55, 6, 0, // packets
+                    0, 0, 0, 0, // padding
+                ]),
+                tc::nlas::Stats2::StatsQueue(vec![
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // requeues
+                    13, 0, 0, 0, // overlimits
+                ]),
+            ]),
+            // Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })
+            tc::nlas::Nla::Stats({
+                let buf = [
+                    28, 146, 82, 7, 0, 0, 0, 0, // bytes
+                    119, 55, 6, 0, // packets
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // overlimits
+                    0, 0, 0, 0, // bps
+                    0, 0, 0, 0, // pps
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                ];
+                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+                tc::nlas::Stats::parse(&stats_buf).unwrap()
+            }),
+        ];
+        messages.push(TcMessage::from_parts(header, nlas));
+
+        // fq_codel
+        // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 2, info: 1 }, nlas: [Kind("fq_codel"), Options([Other(DefaultNla { kind: 1, value: [135, 19, 0, 0] }), Other(DefaultNla { kind: 2, value: [0, 40, 0, 0] }), Other(DefaultNla { kind: 3, value: [159, 134, 1, 0] }), Other(DefaultNla { kind: 4, value: [1, 0, 0, 0] }), Other(DefaultNla { kind: 6, value: [234, 5, 0, 0] }), Other(DefaultNla { kind: 8, value: [64, 0, 0, 0] }), Other(DefaultNla { kind: 9, value: [0, 0, 0, 2] }), Other(DefaultNla { kind: 5, value: [0, 4, 0, 0] })]), HwOffload(0), Stats2([StatsApp([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsBasic([76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 39902796, packets: 165687, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])] }
+        let header = NlTcHeader {
+            family: 0,
+            index: 2,
+            handle: 0,
+            parent: 2,
+            info: 1,
+        };
+        let nlas = vec![
+            tc::nlas::Nla::Kind("fq_codel".to_string()),
+            tc::nlas::Nla::Options({
+                let mut opts = Vec::with_capacity(8);
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    1,
+                    vec![135, 19, 0, 0],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    2,
+                    vec![0, 40, 0, 0],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    3,
+                    vec![159, 134, 1, 0],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    4,
+                    vec![1, 0, 0, 0],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    6,
+                    vec![234, 5, 0, 0],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    8,
+                    vec![64, 0, 0, 0],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    9,
+                    vec![0, 0, 0, 2],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    5,
+                    vec![0, 4, 0, 0],
+                )));
+                opts
+            }),
+            tc::nlas::Nla::HwOffload(0),
+            tc::nlas::Nla::Stats2(vec![
+                tc::nlas::Stats2::StatsApp(vec![
+                    0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                ]),
+                tc::nlas::Stats2::StatsBasic(vec![
+                    76, 222, 96, 2, 0, 0, 0, 0, // bytes
+                    55, 135, 2, 0, // packets
+                    0, 0, 0, 0, // padding
+                ]),
+                tc::nlas::Stats2::StatsQueue(vec![
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // requeues
+                    7, 0, 0, 0, // overlimits
+                ]),
+            ]),
+            tc::nlas::Nla::Stats({
+                let buf = [
+                    76, 222, 96, 2, 0, 0, 0, 0, // bytes
+                    55, 135, 2, 0, // packets
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // overlimits
+                    0, 0, 0, 0, // bps
+                    0, 0, 0, 0, // pps
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                ];
+                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+                tc::nlas::Stats::parse(&stats_buf).unwrap()
+            }),
+            tc::nlas::Nla::XStats(vec![
+                0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]),
+        ];
+        messages.push(TcMessage::from_parts(header, nlas));
+
+        // htb
+        // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65536, parent: 4294967295, info: 2 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 2, value: [17, 0, 3, 0, 10, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }), Other(DefaultNla { kind: 5, value: [232, 3, 0, 0] })]), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
+        let header = NlTcHeader {
+            family: 0,
+            index: 3,
+            handle: 65536,
+            parent: 4294967295,
+            info: 2,
+        };
+        let nlas = vec![
+            tc::nlas::Nla::Kind("htb".to_string()),
+            tc::nlas::Nla::Options({
+                let mut opts = Vec::with_capacity(2);
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    2,
+                    vec![
+                        17, 0, 3, 0, // rate
+                        10, 0, 0, 0, // ceil
+                        32, 0, 0, 0, // buffer
+                        0, 0, 0, 0, // cbuffer
+                        0, 0, 0, 0, // quantum
+                    ],
+                )));
+                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                    5,
+                    vec![232, 3, 0, 0],
+                )));
+                opts
+            }),
+            tc::nlas::Nla::HwOffload(0),
+            tc::nlas::Nla::Stats2(vec![
+                tc::nlas::Stats2::StatsBasic(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                    0, 0, 0, 0, // packets
+                    0, 0, 0, 0, // padding
+                ]),
+                tc::nlas::Stats2::StatsQueue(vec![
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // requeues
+                    0, 0, 0, 0, // overlimits
+                ]),
+            ]),
+            tc::nlas::Nla::Stats({
+                let buf = [
+                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                    0, 0, 0, 0, // packets
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // overlimits
+                    0, 0, 0, 0, // bps
+                    0, 0, 0, 0, // pps
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                ];
+                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+                tc::nlas::Stats::parse(&stats_buf).unwrap()
+            }),
+        ];
+        messages.push(TcMessage::from_parts(header, nlas));
+
+        messages
+}
+
+pub fn nl_classes() -> Vec<TcMessage> {
+    let mut messages = Vec::with_capacity(1);
+
+        // htb
+        // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65537, parent: 4294967295, info: 0 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 1, value: [0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0] })]), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsApp([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])] }
+        let header = NlTcHeader {
+            family: 0,
+            index: 3,
+            handle: 65537,
+            parent: 4294967295,
+            info: 0,
+        };
+        let nlas = vec![
+            tc::nlas::Nla::Kind("htb".to_string()),
+            tc::nlas::Nla::Options(vec![tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                1,
+                vec![
+                    0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0,
+                    64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
+                ],
+            ))]),
+            tc::nlas::Nla::Stats2(vec![
+                tc::nlas::Stats2::StatsBasic(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                    0, 0, 0, 0, // packets
+                    0, 0, 0, 0, // padding
+                ]),
+                tc::nlas::Stats2::StatsQueue(vec![
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // requeues
+                    0, 0, 0, 0, // overlimits
+                ]),
+                tc::nlas::Stats2::StatsApp(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
+                ]),
+            ]),
+            tc::nlas::Nla::Stats({
+                let buf = [
+                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                    0, 0, 0, 0, // packets
+                    0, 0, 0, 0, // drops
+                    0, 0, 0, 0, // overlimits
+                    0, 0, 0, 0, // bps
+                    0, 0, 0, 0, // pps
+                    0, 0, 0, 0, // qlen
+                    0, 0, 0, 0, // backlog
+                ];
+                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+                tc::nlas::Stats::parse(&stats_buf).unwrap()
+            }),
+            tc::nlas::Nla::XStats(vec![
+                0, 0, 0, 0, // lends
+                0, 0, 0, 0, // borrows
+                0, 0, 0, 0, // giants
+                64, 13, 3, 0, // tokens
+                64, 13, 3, 0, // ctokens
+            ]),
+        ];
+        messages.push(TcMessage::from_parts(header, nlas));
+
+        messages
+}
+
+pub fn nl_links() -> Vec<LinkMessage> {
+    let mut msg = LinkMessage::default();
+    msg.header.index = 1;
+    msg.nlas = vec![nlas::link::Nla::IfName("eth0".to_string())];
+    vec![msg]
+}
+
+pub fn qdiscs() -> Vec<TcMsg> {
+    let mut qdiscs = Vec::with_capacity(4);
+
+        // noqueue
+        qdiscs.push(TcMsg {
+            header: TcHeader {
+                index: 1,
+                handle: 0,
+                parent: 4294967295,
+            },
+            attrs: vec![
+                TcAttr::Kind("noqueue".to_string()),
+                TcAttr::Stats(vec![0u8; 36]),
+                TcAttr::Stats2(vec![
+                    TcStats2::StatsBasic(vec![0u8; 16]),
+                    TcStats2::StatsQueue(vec![0u8; 20]),
+                ]),
+                TcAttr::HwOffload(0),
+            ],
+        });
+
+        // mq
+        qdiscs.push(TcMsg {
+            header: TcHeader {
+                index: 2,
+                handle: 0,
+                parent: 4294967295,
+            },
+            attrs: vec![
+                TcAttr::Kind("mq".to_string()),
+                TcAttr::Stats(vec![28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                TcAttr::Stats2(vec![
+                    TcStats2::StatsBasic(vec![28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]),
+                    TcStats2::StatsQueue(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0]),
+                ]),
+                TcAttr::HwOffload(0),
+            ],
+        });
+
+        // fq_codel
+        qdiscs.push(TcMsg {
+            header: TcHeader {
+                index: 2,
+                handle: 0,
+                parent: 2,
+            },
+            attrs: vec![
+                TcAttr::Kind("fq_codel".to_string()),
+                TcAttr::Options(vec![
+                    TcOption {
+                        kind: 1,
+                        bytes: vec![135, 19, 0, 0],
+                    },
+                    TcOption {
+                        kind: 2,
+                        bytes: vec![0, 40, 0, 0],
+                    },
+                    TcOption {
+                        kind: 3,
+                        bytes: vec![159, 134, 1, 0],
+                    },
+                    TcOption {
+                        kind: 4,
+                        bytes: vec![1, 0, 0, 0],
+                    },
+                    TcOption {
+                        kind: 6,
+                        bytes: vec![234, 5, 0, 0],
+                    },
+                    TcOption {
+                        kind: 8,
+                        bytes: vec![64, 0, 0, 0],
+                    },
+                    TcOption {
+                        kind: 9,
+                        bytes: vec![0, 0, 0, 2],
+                    },
+                    TcOption {
+                        kind: 5,
+                        bytes: vec![0, 4, 0, 0],
+                    }
+                ]),
+                TcAttr::Stats(vec![76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                TcAttr::Stats2(vec![
+                    TcStats2::StatsBasic(vec![76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]),
+                    TcStats2::StatsQueue(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0]),
+                    TcStats2::StatsApp(vec![0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                ]),
+                TcAttr::Xstats(vec![
+                    0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                ]),
+                TcAttr::HwOffload(0),
+            ],
+        });
+
+        // htb
+        qdiscs.push(TcMsg {
+            header: TcHeader {
+                index: 3,
+                handle: 65536,
+                parent: 4294967295,
+            },
+            attrs: vec![
+                TcAttr::Kind("htb".to_string()),
+                TcAttr::Options(vec![
+                    TcOption {
+                        kind: 2,
+                        bytes: vec![
+                            17, 0, 3, 0,
+                            10, 0, 0, 0,
+                            32, 0, 0, 0,
+                            0, 0, 0, 0,
+                            0, 0, 0, 0,
+                        ],
+                    },
+                    TcOption {
+                        kind: 5,
+                        bytes: vec![232, 3, 0, 0],
+                    }
+                ]),
+                TcAttr::Stats(vec![0u8; 36]),
+                TcAttr::Stats2(vec![
+                    TcStats2::StatsBasic(vec![0u8; 16]),
+                    TcStats2::StatsQueue(vec![0u8; 20]),
+                ]),
+                TcAttr::HwOffload(0),
+            ],
+        });
+
+
+        qdiscs
+}
+
+pub fn classes() -> Vec<TcMsg> {
+    let mut classes = Vec::with_capacity(1);
+
+    classes.push(
+        TcMsg {
+            header: TcHeader {
+                index: 3,
+                handle: 65537,
+                parent: 4294967295,
+            },
+            attrs: vec![
+                TcAttr::Kind("htb".to_string()),
+                TcAttr::Options(vec![
+                    TcOption {
+                        kind: 1,
+                        bytes: vec![
+                            0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0,
+                            64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
+                        ],
+                    }
+                ]),
+                TcAttr::Stats(vec![0u8; 36]),
+                TcAttr::Stats2(vec![
+                    TcStats2::StatsBasic(vec![
+                        0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                    ]),
+                    TcStats2::StatsQueue(vec![
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                    ]),
+                    TcStats2::StatsApp(vec![
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
+                    ]),
+                ]),
+                TcAttr::Xstats(vec![
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    64, 13, 3, 0,
+                    64, 13, 3, 0,
+                ]),
+            ],
+        }
+    );
+
+    classes
+}
+
+pub fn links() -> Vec<LinkMsg> {
+    vec![
+        LinkMsg {
+            header: LinkHeader {
+                index: 3,
+            },
+            attr: LinkAttr {
+                name: "eth0".to_string()
+            },
+        }
+    ]
+}

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -1,312 +1,312 @@
-use netlink_packet_route::{TcMessage, TcHeader as NlTcHeader, tc, LinkMessage, nlas};
-use netlink_packet_utils::{Parseable, nla};
+use netlink_packet_route::{nlas, tc, LinkMessage, TcHeader as NlTcHeader, TcMessage};
+use netlink_packet_utils::{nla, Parseable};
 
 use crate::types::*;
 
 pub fn nl_qdiscs() -> Vec<TcMessage> {
     let mut messages = Vec::with_capacity(3);
 
-        // noqueue
-        // TcMessage { header: TcHeader { family: 0, index: 1, handle: 0, parent: 4294967295, info: 2 }, nlas: [Kind("noqueue"), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
-        let header = NlTcHeader {
-            family: 0,
-            index: 1,
-            handle: 0,
-            parent: 4294967295,
-            info: 2,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("noqueue".to_string()),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    0, 0, 0, 0, // overlimits
-                ]),
+    // noqueue
+    // TcMessage { header: TcHeader { family: 0, index: 1, handle: 0, parent: 4294967295, info: 2 }, nlas: [Kind("noqueue"), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
+    let header = NlTcHeader {
+        family: 0,
+        index: 1,
+        handle: 0,
+        parent: 4294967295,
+        info: 2,
+    };
+    let nlas = vec![
+        tc::nlas::Nla::Kind("noqueue".to_string()),
+        tc::nlas::Nla::HwOffload(0),
+        tc::nlas::Nla::Stats2(vec![
+            tc::nlas::Stats2::StatsBasic(vec![
+                0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                0, 0, 0, 0, // packets
+                0, 0, 0, 0, // padding
             ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
+            tc::nlas::Stats2::StatsQueue(vec![
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // requeues
+                0, 0, 0, 0, // overlimits
+            ]),
+        ]),
+        tc::nlas::Nla::Stats({
+            let buf = [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // packets
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // overlimits
+                0, 0, 0, 0, // bps
+                0, 0, 0, 0, // pps
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+            ];
+            let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+            tc::nlas::Stats::parse(&stats_buf).unwrap()
+        }),
+    ];
+    messages.push(TcMessage::from_parts(header, nlas));
 
-        // mq
-        // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 4294967295, info: 1 }, nlas: [Kind("mq"), HwOffload(0), Stats2([StatsBasic([28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
-        let header = NlTcHeader {
-            family: 0,
-            index: 2,
-            handle: 0,
-            parent: 4294967295,
-            info: 1,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("mq".to_string()),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    28, 146, 82, 7, 0, 0, 0, 0, // bytes
-                    119, 55, 6, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    13, 0, 0, 0, // overlimits
-                ]),
+    // mq
+    // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 4294967295, info: 1 }, nlas: [Kind("mq"), HwOffload(0), Stats2([StatsBasic([28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
+    let header = NlTcHeader {
+        family: 0,
+        index: 2,
+        handle: 0,
+        parent: 4294967295,
+        info: 1,
+    };
+    let nlas = vec![
+        tc::nlas::Nla::Kind("mq".to_string()),
+        tc::nlas::Nla::HwOffload(0),
+        tc::nlas::Nla::Stats2(vec![
+            tc::nlas::Stats2::StatsBasic(vec![
+                28, 146, 82, 7, 0, 0, 0, 0, // bytes
+                119, 55, 6, 0, // packets
+                0, 0, 0, 0, // padding
             ]),
-            // Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    28, 146, 82, 7, 0, 0, 0, 0, // bytes
-                    119, 55, 6, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
+            tc::nlas::Stats2::StatsQueue(vec![
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // requeues
+                13, 0, 0, 0, // overlimits
+            ]),
+        ]),
+        // Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })
+        tc::nlas::Nla::Stats({
+            let buf = [
+                28, 146, 82, 7, 0, 0, 0, 0, // bytes
+                119, 55, 6, 0, // packets
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // overlimits
+                0, 0, 0, 0, // bps
+                0, 0, 0, 0, // pps
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+            ];
+            let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+            tc::nlas::Stats::parse(&stats_buf).unwrap()
+        }),
+    ];
+    messages.push(TcMessage::from_parts(header, nlas));
 
-        // fq_codel
-        // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 2, info: 1 }, nlas: [Kind("fq_codel"), Options([Other(DefaultNla { kind: 1, value: [135, 19, 0, 0] }), Other(DefaultNla { kind: 2, value: [0, 40, 0, 0] }), Other(DefaultNla { kind: 3, value: [159, 134, 1, 0] }), Other(DefaultNla { kind: 4, value: [1, 0, 0, 0] }), Other(DefaultNla { kind: 6, value: [234, 5, 0, 0] }), Other(DefaultNla { kind: 8, value: [64, 0, 0, 0] }), Other(DefaultNla { kind: 9, value: [0, 0, 0, 2] }), Other(DefaultNla { kind: 5, value: [0, 4, 0, 0] })]), HwOffload(0), Stats2([StatsApp([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsBasic([76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 39902796, packets: 165687, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])] }
-        let header = NlTcHeader {
-            family: 0,
-            index: 2,
-            handle: 0,
-            parent: 2,
-            info: 1,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("fq_codel".to_string()),
-            tc::nlas::Nla::Options({
-                let mut opts = Vec::with_capacity(8);
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    1,
-                    vec![135, 19, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    2,
-                    vec![0, 40, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    3,
-                    vec![159, 134, 1, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    4,
-                    vec![1, 0, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    6,
-                    vec![234, 5, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    8,
-                    vec![64, 0, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    9,
-                    vec![0, 0, 0, 2],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    5,
-                    vec![0, 4, 0, 0],
-                )));
-                opts
-            }),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsApp(vec![
-                    0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                ]),
-                tc::nlas::Stats2::StatsBasic(vec![
-                    76, 222, 96, 2, 0, 0, 0, 0, // bytes
-                    55, 135, 2, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    7, 0, 0, 0, // overlimits
-                ]),
-            ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    76, 222, 96, 2, 0, 0, 0, 0, // bytes
-                    55, 135, 2, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-            tc::nlas::Nla::XStats(vec![
+    // fq_codel
+    // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 2, info: 1 }, nlas: [Kind("fq_codel"), Options([Other(DefaultNla { kind: 1, value: [135, 19, 0, 0] }), Other(DefaultNla { kind: 2, value: [0, 40, 0, 0] }), Other(DefaultNla { kind: 3, value: [159, 134, 1, 0] }), Other(DefaultNla { kind: 4, value: [1, 0, 0, 0] }), Other(DefaultNla { kind: 6, value: [234, 5, 0, 0] }), Other(DefaultNla { kind: 8, value: [64, 0, 0, 0] }), Other(DefaultNla { kind: 9, value: [0, 0, 0, 2] }), Other(DefaultNla { kind: 5, value: [0, 4, 0, 0] })]), HwOffload(0), Stats2([StatsApp([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsBasic([76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 39902796, packets: 165687, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])] }
+    let header = NlTcHeader {
+        family: 0,
+        index: 2,
+        handle: 0,
+        parent: 2,
+        info: 1,
+    };
+    let nlas = vec![
+        tc::nlas::Nla::Kind("fq_codel".to_string()),
+        tc::nlas::Nla::Options({
+            let mut opts = Vec::with_capacity(8);
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                1,
+                vec![135, 19, 0, 0],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                2,
+                vec![0, 40, 0, 0],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                3,
+                vec![159, 134, 1, 0],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                4,
+                vec![1, 0, 0, 0],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                6,
+                vec![234, 5, 0, 0],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                8,
+                vec![64, 0, 0, 0],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                9,
+                vec![0, 0, 0, 2],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                5,
+                vec![0, 4, 0, 0],
+            )));
+            opts
+        }),
+        tc::nlas::Nla::HwOffload(0),
+        tc::nlas::Nla::Stats2(vec![
+            tc::nlas::Stats2::StatsApp(vec![
                 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ]),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
-
-        // htb
-        // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65536, parent: 4294967295, info: 2 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 2, value: [17, 0, 3, 0, 10, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }), Other(DefaultNla { kind: 5, value: [232, 3, 0, 0] })]), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
-        let header = NlTcHeader {
-            family: 0,
-            index: 3,
-            handle: 65536,
-            parent: 4294967295,
-            info: 2,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("htb".to_string()),
-            tc::nlas::Nla::Options({
-                let mut opts = Vec::with_capacity(2);
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    2,
-                    vec![
-                        17, 0, 3, 0, // rate
-                        10, 0, 0, 0, // ceil
-                        32, 0, 0, 0, // buffer
-                        0, 0, 0, 0, // cbuffer
-                        0, 0, 0, 0, // quantum
-                    ],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    5,
-                    vec![232, 3, 0, 0],
-                )));
-                opts
-            }),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    0, 0, 0, 0, // overlimits
-                ]),
+            tc::nlas::Stats2::StatsBasic(vec![
+                76, 222, 96, 2, 0, 0, 0, 0, // bytes
+                55, 135, 2, 0, // packets
+                0, 0, 0, 0, // padding
             ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
+            tc::nlas::Stats2::StatsQueue(vec![
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // requeues
+                7, 0, 0, 0, // overlimits
+            ]),
+        ]),
+        tc::nlas::Nla::Stats({
+            let buf = [
+                76, 222, 96, 2, 0, 0, 0, 0, // bytes
+                55, 135, 2, 0, // packets
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // overlimits
+                0, 0, 0, 0, // bps
+                0, 0, 0, 0, // pps
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+            ];
+            let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+            tc::nlas::Stats::parse(&stats_buf).unwrap()
+        }),
+        tc::nlas::Nla::XStats(vec![
+            0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]),
+    ];
+    messages.push(TcMessage::from_parts(header, nlas));
 
-        messages
+    // htb
+    // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65536, parent: 4294967295, info: 2 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 2, value: [17, 0, 3, 0, 10, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }), Other(DefaultNla { kind: 5, value: [232, 3, 0, 0] })]), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
+    let header = NlTcHeader {
+        family: 0,
+        index: 3,
+        handle: 65536,
+        parent: 4294967295,
+        info: 2,
+    };
+    let nlas = vec![
+        tc::nlas::Nla::Kind("htb".to_string()),
+        tc::nlas::Nla::Options({
+            let mut opts = Vec::with_capacity(2);
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                2,
+                vec![
+                    17, 0, 3, 0, // rate
+                    10, 0, 0, 0, // ceil
+                    32, 0, 0, 0, // buffer
+                    0, 0, 0, 0, // cbuffer
+                    0, 0, 0, 0, // quantum
+                ],
+            )));
+            opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+                5,
+                vec![232, 3, 0, 0],
+            )));
+            opts
+        }),
+        tc::nlas::Nla::HwOffload(0),
+        tc::nlas::Nla::Stats2(vec![
+            tc::nlas::Stats2::StatsBasic(vec![
+                0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                0, 0, 0, 0, // packets
+                0, 0, 0, 0, // padding
+            ]),
+            tc::nlas::Stats2::StatsQueue(vec![
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // requeues
+                0, 0, 0, 0, // overlimits
+            ]),
+        ]),
+        tc::nlas::Nla::Stats({
+            let buf = [
+                0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                0, 0, 0, 0, // packets
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // overlimits
+                0, 0, 0, 0, // bps
+                0, 0, 0, 0, // pps
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+            ];
+            let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+            tc::nlas::Stats::parse(&stats_buf).unwrap()
+        }),
+    ];
+    messages.push(TcMessage::from_parts(header, nlas));
+
+    messages
 }
 
 pub fn nl_classes() -> Vec<TcMessage> {
     let mut messages = Vec::with_capacity(1);
 
-        // htb
-        // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65537, parent: 4294967295, info: 0 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 1, value: [0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0] })]), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsApp([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])] }
-        let header = NlTcHeader {
-            family: 0,
-            index: 3,
-            handle: 65537,
-            parent: 4294967295,
-            info: 0,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("htb".to_string()),
-            tc::nlas::Nla::Options(vec![tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                1,
-                vec![
-                    0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0,
-                    64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
-                ],
-            ))]),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    0, 0, 0, 0, // overlimits
-                ]),
-                tc::nlas::Stats2::StatsApp(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
-                ]),
+    // htb
+    // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65537, parent: 4294967295, info: 0 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 1, value: [0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0] })]), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsApp([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])] }
+    let header = NlTcHeader {
+        family: 0,
+        index: 3,
+        handle: 65537,
+        parent: 4294967295,
+        info: 0,
+    };
+    let nlas = vec![
+        tc::nlas::Nla::Kind("htb".to_string()),
+        tc::nlas::Nla::Options(vec![tc::nlas::TcOpt::Other(nla::DefaultNla::new(
+            1,
+            vec![
+                0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 64,
+                13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        ))]),
+        tc::nlas::Nla::Stats2(vec![
+            tc::nlas::Stats2::StatsBasic(vec![
+                0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                0, 0, 0, 0, // packets
+                0, 0, 0, 0, // padding
             ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-            tc::nlas::Nla::XStats(vec![
-                0, 0, 0, 0, // lends
-                0, 0, 0, 0, // borrows
-                0, 0, 0, 0, // giants
-                64, 13, 3, 0, // tokens
-                64, 13, 3, 0, // ctokens
+            tc::nlas::Stats2::StatsQueue(vec![
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // requeues
+                0, 0, 0, 0, // overlimits
             ]),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
+            tc::nlas::Stats2::StatsApp(vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
+            ]),
+        ]),
+        tc::nlas::Nla::Stats({
+            let buf = [
+                0, 0, 0, 0, 0, 0, 0, 0, // bytes
+                0, 0, 0, 0, // packets
+                0, 0, 0, 0, // drops
+                0, 0, 0, 0, // overlimits
+                0, 0, 0, 0, // bps
+                0, 0, 0, 0, // pps
+                0, 0, 0, 0, // qlen
+                0, 0, 0, 0, // backlog
+            ];
+            let stats_buf = tc::nlas::StatsBuffer::new(&buf);
+            tc::nlas::Stats::parse(&stats_buf).unwrap()
+        }),
+        tc::nlas::Nla::XStats(vec![
+            0, 0, 0, 0, // lends
+            0, 0, 0, 0, // borrows
+            0, 0, 0, 0, // giants
+            64, 13, 3, 0, // tokens
+            64, 13, 3, 0, // ctokens
+        ]),
+    ];
+    messages.push(TcMessage::from_parts(header, nlas));
 
-        messages
+    messages
 }
 
 pub fn nl_links() -> Vec<LinkMessage> {
@@ -319,199 +319,187 @@ pub fn nl_links() -> Vec<LinkMessage> {
 pub fn qdiscs() -> Vec<TcMsg> {
     let mut qdiscs = Vec::with_capacity(4);
 
-        // noqueue
-        qdiscs.push(TcMsg {
-            header: TcHeader {
-                index: 1,
-                handle: 0,
-                parent: 4294967295,
-            },
-            attrs: vec![
-                TcAttr::Kind("noqueue".to_string()),
-                TcAttr::Stats(vec![0u8; 36]),
-                TcAttr::Stats2(vec![
-                    TcStats2::StatsBasic(vec![0u8; 16]),
-                    TcStats2::StatsQueue(vec![0u8; 20]),
-                ]),
-                TcAttr::HwOffload(0),
-            ],
-        });
+    // noqueue
+    qdiscs.push(TcMsg {
+        header: TcHeader {
+            index: 1,
+            handle: 0,
+            parent: 4294967295,
+        },
+        attrs: vec![
+            TcAttr::Kind("noqueue".to_string()),
+            TcAttr::Stats(vec![0u8; 36]),
+            TcAttr::Stats2(vec![
+                TcStats2::StatsBasic(vec![0u8; 16]),
+                TcStats2::StatsQueue(vec![0u8; 20]),
+            ]),
+            TcAttr::HwOffload(0),
+        ],
+    });
 
-        // mq
-        qdiscs.push(TcMsg {
-            header: TcHeader {
-                index: 2,
-                handle: 0,
-                parent: 4294967295,
-            },
-            attrs: vec![
-                TcAttr::Kind("mq".to_string()),
-                TcAttr::Stats(vec![28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-                TcAttr::Stats2(vec![
-                    TcStats2::StatsBasic(vec![28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]),
-                    TcStats2::StatsQueue(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0]),
+    // mq
+    qdiscs.push(TcMsg {
+        header: TcHeader {
+            index: 2,
+            handle: 0,
+            parent: 4294967295,
+        },
+        attrs: vec![
+            TcAttr::Kind("mq".to_string()),
+            TcAttr::Stats(vec![
+                28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]),
+            TcAttr::Stats2(vec![
+                TcStats2::StatsBasic(vec![28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]),
+                TcStats2::StatsQueue(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0,
                 ]),
-                TcAttr::HwOffload(0),
-            ],
-        });
+            ]),
+            TcAttr::HwOffload(0),
+        ],
+    });
 
-        // fq_codel
-        qdiscs.push(TcMsg {
-            header: TcHeader {
-                index: 2,
-                handle: 0,
-                parent: 2,
-            },
-            attrs: vec![
-                TcAttr::Kind("fq_codel".to_string()),
-                TcAttr::Options(vec![
-                    TcOption {
-                        kind: 1,
-                        bytes: vec![135, 19, 0, 0],
-                    },
-                    TcOption {
-                        kind: 2,
-                        bytes: vec![0, 40, 0, 0],
-                    },
-                    TcOption {
-                        kind: 3,
-                        bytes: vec![159, 134, 1, 0],
-                    },
-                    TcOption {
-                        kind: 4,
-                        bytes: vec![1, 0, 0, 0],
-                    },
-                    TcOption {
-                        kind: 6,
-                        bytes: vec![234, 5, 0, 0],
-                    },
-                    TcOption {
-                        kind: 8,
-                        bytes: vec![64, 0, 0, 0],
-                    },
-                    TcOption {
-                        kind: 9,
-                        bytes: vec![0, 0, 0, 2],
-                    },
-                    TcOption {
-                        kind: 5,
-                        bytes: vec![0, 4, 0, 0],
-                    }
+    // fq_codel
+    qdiscs.push(TcMsg {
+        header: TcHeader {
+            index: 2,
+            handle: 0,
+            parent: 2,
+        },
+        attrs: vec![
+            TcAttr::Kind("fq_codel".to_string()),
+            TcAttr::Options(vec![
+                TcOption {
+                    kind: 1,
+                    bytes: vec![135, 19, 0, 0],
+                },
+                TcOption {
+                    kind: 2,
+                    bytes: vec![0, 40, 0, 0],
+                },
+                TcOption {
+                    kind: 3,
+                    bytes: vec![159, 134, 1, 0],
+                },
+                TcOption {
+                    kind: 4,
+                    bytes: vec![1, 0, 0, 0],
+                },
+                TcOption {
+                    kind: 6,
+                    bytes: vec![234, 5, 0, 0],
+                },
+                TcOption {
+                    kind: 8,
+                    bytes: vec![64, 0, 0, 0],
+                },
+                TcOption {
+                    kind: 9,
+                    bytes: vec![0, 0, 0, 2],
+                },
+                TcOption {
+                    kind: 5,
+                    bytes: vec![0, 4, 0, 0],
+                },
+            ]),
+            TcAttr::Stats(vec![
+                76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]),
+            TcAttr::Stats2(vec![
+                TcStats2::StatsBasic(vec![76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]),
+                TcStats2::StatsQueue(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0,
                 ]),
-                TcAttr::Stats(vec![76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-                TcAttr::Stats2(vec![
-                    TcStats2::StatsBasic(vec![76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]),
-                    TcStats2::StatsQueue(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0]),
-                    TcStats2::StatsApp(vec![0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                TcStats2::StatsApp(vec![
+                    0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 ]),
-                TcAttr::Xstats(vec![
-                    0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                ]),
-                TcAttr::HwOffload(0),
-            ],
-        });
+            ]),
+            TcAttr::Xstats(vec![
+                0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]),
+            TcAttr::HwOffload(0),
+        ],
+    });
 
-        // htb
-        qdiscs.push(TcMsg {
-            header: TcHeader {
-                index: 3,
-                handle: 65536,
-                parent: 4294967295,
-            },
-            attrs: vec![
-                TcAttr::Kind("htb".to_string()),
-                TcAttr::Options(vec![
-                    TcOption {
-                        kind: 2,
-                        bytes: vec![
-                            17, 0, 3, 0,
-                            10, 0, 0, 0,
-                            32, 0, 0, 0,
-                            0, 0, 0, 0,
-                            0, 0, 0, 0,
-                        ],
-                    },
-                    TcOption {
-                        kind: 5,
-                        bytes: vec![232, 3, 0, 0],
-                    }
-                ]),
-                TcAttr::Stats(vec![0u8; 36]),
-                TcAttr::Stats2(vec![
-                    TcStats2::StatsBasic(vec![0u8; 16]),
-                    TcStats2::StatsQueue(vec![0u8; 20]),
-                ]),
-                TcAttr::HwOffload(0),
-            ],
-        });
+    // htb
+    qdiscs.push(TcMsg {
+        header: TcHeader {
+            index: 3,
+            handle: 65536,
+            parent: 4294967295,
+        },
+        attrs: vec![
+            TcAttr::Kind("htb".to_string()),
+            TcAttr::Options(vec![
+                TcOption {
+                    kind: 2,
+                    bytes: vec![
+                        17, 0, 3, 0, 10, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    ],
+                },
+                TcOption {
+                    kind: 5,
+                    bytes: vec![232, 3, 0, 0],
+                },
+            ]),
+            TcAttr::Stats(vec![0u8; 36]),
+            TcAttr::Stats2(vec![
+                TcStats2::StatsBasic(vec![0u8; 16]),
+                TcStats2::StatsQueue(vec![0u8; 20]),
+            ]),
+            TcAttr::HwOffload(0),
+        ],
+    });
 
-
-        qdiscs
+    qdiscs
 }
 
 pub fn classes() -> Vec<TcMsg> {
     let mut classes = Vec::with_capacity(1);
 
-    classes.push(
-        TcMsg {
-            header: TcHeader {
-                index: 3,
-                handle: 65537,
-                parent: 4294967295,
-            },
-            attrs: vec![
-                TcAttr::Kind("htb".to_string()),
-                TcAttr::Options(vec![
-                    TcOption {
-                        kind: 1,
-                        bytes: vec![
-                            0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0,
-                            64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
-                        ],
-                    }
+    classes.push(TcMsg {
+        header: TcHeader {
+            index: 3,
+            handle: 65537,
+            parent: 4294967295,
+        },
+        attrs: vec![
+            TcAttr::Kind("htb".to_string()),
+            TcAttr::Options(vec![TcOption {
+                kind: 1,
+                bytes: vec![
+                    0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0,
+                    64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
+                ],
+            }]),
+            TcAttr::Stats(vec![0u8; 36]),
+            TcAttr::Stats2(vec![
+                TcStats2::StatsBasic(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                TcStats2::StatsQueue(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 ]),
-                TcAttr::Stats(vec![0u8; 36]),
-                TcAttr::Stats2(vec![
-                    TcStats2::StatsBasic(vec![
-                        0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                    ]),
-                    TcStats2::StatsQueue(vec![
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                    ]),
-                    TcStats2::StatsApp(vec![
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
-                    ]),
+                TcStats2::StatsApp(vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
                 ]),
-                TcAttr::Xstats(vec![
-                    0, 0, 0, 0,
-                    0, 0, 0, 0,
-                    0, 0, 0, 0,
-                    64, 13, 3, 0,
-                    64, 13, 3, 0,
-                ]),
-            ],
-        }
-    );
+            ]),
+            TcAttr::Xstats(vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
+            ]),
+        ],
+    });
 
     classes
 }
 
 pub fn links() -> Vec<LinkMsg> {
-    vec![
-        LinkMsg {
-            header: LinkHeader {
-                index: 3,
-            },
-            attr: LinkAttr {
-                name: "eth0".to_string()
-            },
-        }
-    ]
+    vec![LinkMsg {
+        header: LinkHeader { index: 3 },
+        attr: LinkAttr {
+            name: "eth0".to_string(),
+        },
+    }]
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,3 @@
-use netlink_packet_route::{nlas, tc, LinkMessage, TcHeader, TcMessage};
-use netlink_packet_utils::{nla, Parseable};
-
 use crate::{errors::NetlinkError, netlink::NetlinkConnection};
 
 use super::*;
@@ -15,323 +12,22 @@ impl NetlinkConnection for MockNetlink {
         Ok(MockNetlink {})
     }
 
-    fn qdiscs(&self) -> Result<Vec<TcMessage>, NetlinkError> {
-        let mut messages = Vec::with_capacity(3);
-
-        // noqueue
-        // TcMessage { header: TcHeader { family: 0, index: 1, handle: 0, parent: 4294967295, info: 2 }, nlas: [Kind("noqueue"), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
-        let header = TcHeader {
-            family: 0,
-            index: 1,
-            handle: 0,
-            parent: 4294967295,
-            info: 2,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("noqueue".to_string()),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    0, 0, 0, 0, // overlimits
-                ]),
-            ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
-
-        // mq
-        // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 4294967295, info: 1 }, nlas: [Kind("mq"), HwOffload(0), Stats2([StatsBasic([28, 146, 82, 7, 0, 0, 0, 0, 119, 55, 6, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
-        let header = TcHeader {
-            family: 0,
-            index: 2,
-            handle: 0,
-            parent: 4294967295,
-            info: 1,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("mq".to_string()),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    28, 146, 82, 7, 0, 0, 0, 0, // bytes
-                    119, 55, 6, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    13, 0, 0, 0, // overlimits
-                ]),
-            ]),
-            // Stats(Stats { bytes: 122851868, packets: 407415, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    28, 146, 82, 7, 0, 0, 0, 0, // bytes
-                    119, 55, 6, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
-
-        // fq_codel
-        // TcMessage { header: TcHeader { family: 0, index: 2, handle: 0, parent: 2, info: 1 }, nlas: [Kind("fq_codel"), Options([Other(DefaultNla { kind: 1, value: [135, 19, 0, 0] }), Other(DefaultNla { kind: 2, value: [0, 40, 0, 0] }), Other(DefaultNla { kind: 3, value: [159, 134, 1, 0] }), Other(DefaultNla { kind: 4, value: [1, 0, 0, 0] }), Other(DefaultNla { kind: 6, value: [234, 5, 0, 0] }), Other(DefaultNla { kind: 8, value: [64, 0, 0, 0] }), Other(DefaultNla { kind: 9, value: [0, 0, 0, 2] }), Other(DefaultNla { kind: 5, value: [0, 4, 0, 0] })]), HwOffload(0), Stats2([StatsApp([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsBasic([76, 222, 96, 2, 0, 0, 0, 0, 55, 135, 2, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 39902796, packets: 165687, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])] }
-        let header = TcHeader {
-            family: 0,
-            index: 2,
-            handle: 0,
-            parent: 2,
-            info: 1,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("fq_codel".to_string()),
-            tc::nlas::Nla::Options({
-                let mut opts = Vec::with_capacity(8);
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    1,
-                    vec![135, 19, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    2,
-                    vec![0, 40, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    3,
-                    vec![159, 134, 1, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    4,
-                    vec![1, 0, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    6,
-                    vec![234, 5, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    8,
-                    vec![64, 0, 0, 0],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    9,
-                    vec![0, 0, 0, 2],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    5,
-                    vec![0, 4, 0, 0],
-                )));
-                opts
-            }),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsApp(vec![
-                    0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                ]),
-                tc::nlas::Stats2::StatsBasic(vec![
-                    76, 222, 96, 2, 0, 0, 0, 0, // bytes
-                    55, 135, 2, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    7, 0, 0, 0, // overlimits
-                ]),
-            ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    76, 222, 96, 2, 0, 0, 0, 0, // bytes
-                    55, 135, 2, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-            tc::nlas::Nla::XStats(vec![
-                0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            ]),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
-
-        // htb
-        // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65536, parent: 4294967295, info: 2 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 2, value: [17, 0, 3, 0, 10, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }), Other(DefaultNla { kind: 5, value: [232, 3, 0, 0] })]), HwOffload(0), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 })] }
-        let header = TcHeader {
-            family: 0,
-            index: 3,
-            handle: 65536,
-            parent: 4294967295,
-            info: 2,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("htb".to_string()),
-            tc::nlas::Nla::Options({
-                let mut opts = Vec::with_capacity(2);
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    2,
-                    vec![
-                        17, 0, 3, 0, // rate
-                        10, 0, 0, 0, // ceil
-                        32, 0, 0, 0, // buffer
-                        0, 0, 0, 0, // cbuffer
-                        0, 0, 0, 0, // quantum
-                    ],
-                )));
-                opts.push(tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                    5,
-                    vec![232, 3, 0, 0],
-                )));
-                opts
-            }),
-            tc::nlas::Nla::HwOffload(0),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    0, 0, 0, 0, // overlimits
-                ]),
-            ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
-
-        Ok(messages)
+    fn qdiscs(&self) -> Result<Vec<TcMsg>, NetlinkError> {
+        Ok(test_data::qdiscs())
     }
 
-    fn classes(&self, _: i32) -> Result<Vec<TcMessage>, NetlinkError> {
-        let mut messages = Vec::with_capacity(1);
-
-        // htb
-        // TcMessage { header: TcHeader { family: 0, index: 3, handle: 65537, parent: 4294967295, info: 0 }, nlas: [Kind("htb"), Options([Other(DefaultNla { kind: 1, value: [0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0] })]), Stats2([StatsBasic([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsQueue([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), StatsApp([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])]), Stats(Stats { bytes: 0, packets: 0, drops: 0, overlimits: 0, bps: 0, pps: 0, qlen: 0, backlog: 0 }), XStats([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0])] }
-        let header = TcHeader {
-            family: 0,
-            index: 3,
-            handle: 65537,
-            parent: 4294967295,
-            info: 0,
-        };
-        let nlas = vec![
-            tc::nlas::Nla::Kind("htb".to_string()),
-            tc::nlas::Nla::Options(vec![tc::nlas::TcOpt::Other(nla::DefaultNla::new(
-                1,
-                vec![
-                    0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 72, 232, 1, 0,
-                    64, 13, 3, 0, 64, 13, 3, 0, 212, 48, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0,
-                ],
-            ))]),
-            tc::nlas::Nla::Stats2(vec![
-                tc::nlas::Stats2::StatsBasic(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // padding
-                ]),
-                tc::nlas::Stats2::StatsQueue(vec![
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // requeues
-                    0, 0, 0, 0, // overlimits
-                ]),
-                tc::nlas::Stats2::StatsApp(vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 13, 3, 0, 64, 13, 3, 0,
-                ]),
-            ]),
-            tc::nlas::Nla::Stats({
-                let buf = [
-                    0, 0, 0, 0, 0, 0, 0, 0, // bytes
-                    0, 0, 0, 0, // packets
-                    0, 0, 0, 0, // drops
-                    0, 0, 0, 0, // overlimits
-                    0, 0, 0, 0, // bps
-                    0, 0, 0, 0, // pps
-                    0, 0, 0, 0, // qlen
-                    0, 0, 0, 0, // backlog
-                ];
-                let stats_buf = tc::nlas::StatsBuffer::new(&buf);
-                tc::nlas::Stats::parse(&stats_buf).unwrap()
-            }),
-            tc::nlas::Nla::XStats(vec![
-                0, 0, 0, 0, // lends
-                0, 0, 0, 0, // borrows
-                0, 0, 0, 0, // giants
-                64, 13, 3, 0, // tokens
-                64, 13, 3, 0, // ctokens
-            ]),
-        ];
-        messages.push(TcMessage::from_parts(header, nlas));
-
-        Ok(messages)
+    fn classes(&self, _: i32) -> Result<Vec<TcMsg>, NetlinkError> {
+        Ok(test_data::classes())
     }
 
-    fn links(&self) -> Result<Vec<LinkMessage>, NetlinkError> {
-        let mut msg = LinkMessage::default();
-        msg.header.index = 3;
-        msg.nlas = vec![nlas::link::Nla::IfName("eth0".to_string())];
-        Ok(vec![msg])
+    fn links(&self) -> Result<Vec<LinkMsg>, NetlinkError> {
+        Ok(test_data::links())
     }
 }
 
 #[test]
 fn test_no_queue() {
-    let stats = nl_tc_stats::<MockNetlink>().unwrap();
+    let stats = nl_qdiscs::<MockNetlink>().unwrap();
 
     let tc = stats.get(0).unwrap();
     // message
@@ -339,7 +35,7 @@ fn test_no_queue() {
     assert_eq!(tc.msg.handle, 0);
     assert_eq!(tc.msg.parent, 4294967295);
     // attr
-    assert_eq!(tc.attr.kind.as_ref().unwrap(), "noqueue");
+    assert_eq!(tc.attr.kind.as_str(), "noqueue");
     let basic = tc.attr.stats2.as_ref().unwrap().basic.as_ref().unwrap();
     assert_eq!(basic.bytes, 0);
     assert_eq!(basic.packets, 0);
@@ -352,7 +48,7 @@ fn test_no_queue() {
 
 #[test]
 fn test_mq() {
-    let stats = nl_tc_stats::<MockNetlink>().unwrap();
+    let stats = nl_qdiscs::<MockNetlink>().unwrap();
 
     let tc = stats.get(1).unwrap();
     // message
@@ -360,7 +56,7 @@ fn test_mq() {
     assert_eq!(tc.msg.handle, 0);
     assert_eq!(tc.msg.parent, 4294967295);
     // attr
-    assert_eq!(tc.attr.kind.as_ref().unwrap(), "mq");
+    assert_eq!(tc.attr.kind.as_str(), "mq");
     let basic = tc.attr.stats2.as_ref().unwrap().basic.as_ref().unwrap();
     assert_eq!(basic.bytes, 122851868);
     assert_eq!(basic.packets, 407415);
@@ -374,7 +70,7 @@ fn test_mq() {
 
 #[test]
 fn test_fq_codel() {
-    let stats = nl_tc_stats::<MockNetlink>().unwrap();
+    let stats = nl_qdiscs::<MockNetlink>().unwrap();
 
     let tc = stats.get(2).unwrap();
     // message
@@ -382,7 +78,7 @@ fn test_fq_codel() {
     assert_eq!(tc.msg.handle, 0);
     assert_eq!(tc.msg.parent, 2);
     // attr
-    assert_eq!(tc.attr.kind.as_ref().unwrap(), "fq_codel");
+    assert_eq!(tc.attr.kind.as_str(), "fq_codel");
     let basic = tc.attr.stats2.as_ref().unwrap().basic.as_ref().unwrap();
     assert_eq!(basic.bytes, 39902796);
     assert_eq!(basic.packets, 165687);
@@ -437,7 +133,7 @@ fn test_htb() {
     assert_eq!(tc.msg.handle, 65536);
     assert_eq!(tc.msg.parent, 4294967295);
     // attr
-    assert_eq!(tc.attr.kind.as_ref().unwrap(), "htb");
+    assert_eq!(tc.attr.kind.as_str(), "htb");
     let basic = tc.attr.stats2.as_ref().unwrap().basic.as_ref().unwrap();
     assert_eq!(basic.bytes, 0);
     assert_eq!(basic.packets, 0);
@@ -496,9 +192,9 @@ fn test_htb() {
             init: None,
             ctab: vec![],
             rtab: vec![],
-            direct_qlen: 0,
-            rate64: 0,
-            ceil64: 0,
+            direct_qlen: None,
+            rate64: None,
+            ceil64: None,
         })
     );
     // xstats

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,65 @@ use serde::{Deserialize, Serialize};
 
 use crate::{errors::TcError, Clsact, FqCodel, FqCodelXStats, Htb, HtbGlob, HtbXstats};
 
+/// This struct is an intermediate representation for netlink `tc` messages.
+/// Any downstream structs should be constructed into this struct.
+#[derive(Default, PartialEq)]
+pub struct TcMsg {
+    pub header: TcHeader,
+    pub attrs: Vec<TcAttr>,
+}
+
+#[derive(Default, PartialEq)]
+pub struct TcHeader {
+    pub index: i32,
+    pub handle: u32,
+    pub parent: u32,
+}
+
+#[derive(PartialEq)]
+pub enum TcAttr {
+    Unspec(Vec<u8>),
+    Kind(String),
+    Options(Vec<TcOption>),
+    Stats(Vec<u8>),
+    Xstats(Vec<u8>),
+    Rate(Vec<u8>),
+    Fcnt(Vec<u8>),
+    Stats2(Vec<TcStats2>),
+    Stab(Vec<u8>),
+    Pad(Vec<u8>),
+    Chain(Vec<u8>),
+    HwOffload(u8),
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct TcOption {
+    pub kind: u16,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(PartialEq)]
+pub enum TcStats2 {
+    StatsBasic(Vec<u8>),
+    StatsQueue(Vec<u8>),
+    StatsApp(Vec<u8>),
+}
+
+/// This struct is an intermediate representation for netlink `link` messages.
+/// Any downstream structs should be constructed into this struct.
+pub struct LinkMsg {
+    pub header: LinkHeader,
+    pub attr: LinkAttr,
+}
+
+pub struct LinkHeader {
+    pub index: u32,
+}
+
+pub struct LinkAttr {
+    pub name: String,
+}
+
 #[derive(Debug, Default)]
 pub struct Tc {
     pub msg: TcMessage,
@@ -17,7 +76,7 @@ pub struct TcMessage {
 
 #[derive(Debug, Default)]
 pub struct Attribute {
-    pub kind: Option<String>,
+    pub kind: String,
     pub stats: Option<Stats>,
     pub stats2: Option<Stats2>,
     pub qdisc: Option<QDisc>,
@@ -25,7 +84,7 @@ pub struct Attribute {
     pub xstats: Option<XStats>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Stats {
     pub bytes: u64,
     pub packets: u32,
@@ -37,13 +96,13 @@ pub struct Stats {
     pub backlog: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct StatsBasic {
     pub bytes: u64,
     pub packets: u32,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct StatsQueue {
     pub qlen: u32,
     pub backlog: u32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,20 +4,20 @@ use crate::{errors::TcError, Clsact, FqCodel, FqCodelXStats, Htb, HtbGlob, HtbXs
 
 /// This struct is an intermediate representation for netlink `tc` messages.
 /// Any downstream structs should be constructed into this struct.
-#[derive(Default, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct TcMsg {
     pub header: TcHeader,
     pub attrs: Vec<TcAttr>,
 }
 
-#[derive(Default, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct TcHeader {
     pub index: i32,
     pub handle: u32,
     pub parent: u32,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum TcAttr {
     Unspec(Vec<u8>),
     Kind(String),
@@ -33,13 +33,13 @@ pub enum TcAttr {
     HwOffload(u8),
 }
 
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct TcOption {
     pub kind: u16,
     pub bytes: Vec<u8>,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum TcStats2 {
     StatsBasic(Vec<u8>),
     StatsQueue(Vec<u8>),
@@ -48,15 +48,18 @@ pub enum TcStats2 {
 
 /// This struct is an intermediate representation for netlink `link` messages.
 /// Any downstream structs should be constructed into this struct.
+#[derive(Debug)]
 pub struct LinkMsg {
     pub header: LinkHeader,
     pub attr: LinkAttr,
 }
 
+#[derive(Debug)]
 pub struct LinkHeader {
     pub index: u32,
 }
 
+#[derive(Debug)]
 pub struct LinkAttr {
     pub name: String,
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,7 +7,7 @@ fn test_get_qdiscs() {
     let tcs = result.unwrap();
     for tc in tcs {
         let attr = tc.attr;
-        assert!(attr.kind.is_some());
+        assert!(!attr.kind.is_empty());
         assert!(attr.stats.is_some());
         assert!(attr.stats2.is_some());
     }


### PR DESCRIPTION
Add intermediate types.
Netlink struct read from library is converted to these intermediate types which is then converted to the final types.
This allows upgrading or changing underlying netlink libraries easier (could also allow for IoC).

Resolves #46 